### PR TITLE
[ui/dockmenu-16] ✨ feat: DockMenu 기본 골격 구현 및 테스트 코드 추가

### DIFF
--- a/app/(shell)/_components/dock/DockMenu.test.tsx
+++ b/app/(shell)/_components/dock/DockMenu.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import DockMenu from "./DockMenu";
+
+describe("DockMenu", () => {
+  test("독메뉴 네비게이션이 렌더링된다", () => {
+    render(<DockMenu />);
+    expect(
+      screen.getByRole("navigation", { name: /Dock menu/i })
+    ).toBeInTheDocument();
+  });
+
+  test("모든 메뉴 아이템이 aria-label 기준으로 렌더링된다", () => {
+    render(<DockMenu />);
+    const labels = ["DEV_LOG", "INSIGHT", "JOURNAL", "CONTACT", "PHOTOBOOTH"];
+
+    labels.forEach((label) => {
+      expect(screen.getByLabelText(label)).toBeInTheDocument();
+    });
+  });
+});

--- a/app/(shell)/_components/dock/DockMenu.tsx
+++ b/app/(shell)/_components/dock/DockMenu.tsx
@@ -1,6 +1,42 @@
+import Link from "next/link";
 
 export default function DockMenu() {
   return (
-    <div>DockMenu</div>
-  )
+    <div className="fixed inset-0 pointer-events-none z-50">
+      <nav 
+      aria-label="Dock menu"
+      className="pointer-events-auto absolute bottom-10 left-1/2 -translate-x-1/2
+                bg-foreground/10 text-foreground px-10 py-3 rounded-3xl"
+      >
+        <ul className="flex items-center gap-10">
+          <li>
+            <Link aria-label="DEV_LOG" href="/DEV_LOG">
+              DEV_LOG
+            </Link>
+          </li>
+          <li>
+            <Link aria-label="INSIGHT" href="/INSIGHT">
+              INSIGHT
+            </Link>
+          </li>
+          <li>
+            <Link aria-label="JOURNAL" href="/JOURNAL">
+              JOURNAL
+            </Link>
+          </li>
+          <li aria-hidden="true" className="h-4 w-px bg-gray-300 mx-2" />
+          <li>
+            <button aria-label="CONTACT">
+              Contact
+            </button>
+          </li>
+          <li>
+            <button aria-label="PHOTOBOOTH">
+              Photo
+            </button>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  );
 }


### PR DESCRIPTION
## 요약
- 변경 목적(왜?): DockMenu의 기본 골격을 렌더링하고, 각 메뉴 아이템이 정상적으로 표시되는지 확인하기 위함
- 주요 변경(무엇을?): DockMenu 컴포넌트 생성 및 aria-label 기반 렌더링 테스트 추가

## 변경 내용
- [x] UI/컴포넌트  
  - DockMenu 기본 구조 구현 (`nav` / `ul` / `li` / `Link` / `button`)
  - 고정 위치(fixed) 플로팅 레이아웃 적용
  - aria-label 기반 접근성 구조 추가
- [x] 로직/유틸  
  - 메뉴 렌더링 검증을 위한 기본 유닛 테스트 작성
- [ ] 문서/설정 (해당 없음)

## 스크린샷/동영상 (선택)
<!-- UI 변경 있으면 첨부 -->
<img width="604" height="230" alt="스크린샷 2025-11-17 오전 8 55 22" src="https://github.com/user-attachments/assets/b96c148a-7c50-443a-b2c5-d8308a569122" />


## 테스트
- [x] 유닛 테스트 추가됨  
  - DockMenu 네비게이션 렌더링 테스트  
  - aria-label 기준 메뉴 아이템 렌더링 테스트  
- [x] 로컬에서 `pnpm test` 통과  
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈
#16 
