### PR TITLE
[infra/devCi-55] 📝 Chore: dev 브랜치 PR CI 테스트 자동 실행 설정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - dev
 
 jobs:
   ci:


### PR DESCRIPTION
## 요약
- 변경 목적(왜?):  
  - 기존에는 `main` 브랜치로 향하는 PR에서만 CI가 실행되어, `dev` 브랜치 작업에 대한 테스트 자동화가 미적용
  - `dev` 브랜치로 향하는 PR에서도 테스트를 자동으로 실행하여, 기능 개발 단계에서부터 문제를 조기에 발견하기 위함
- 주요 변경(무엇을?):  
  - GitHub Actions 워크플로의 `on.pull_request.branches` 설정에 `dev` 브랜치 추가  
  - `feature → dev` PR에서도 CI 테스트가 자동 실행되도록 트리거 수정

---

## 변경 내용
- [ ] UI/컴포넌트
- [ ] 로직/유틸
- [x] 문서/설정  
  - GitHub Actions 워크플로 트리거 수정  
  - `pull_request.branches`에 `dev` 추가 (`main`, `dev` 모두에서 PR 시 CI 실행)

---

## 스크린샷/동영상 (선택)

---

## 테스트
- [ ] 유닛 테스트 추가/수정됨
- [ ] 로컬에서 `pnpm test` 통과
- [ ] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)
- [x] `feature → dev` PR 생성 시 CI가 자동 실행되는지 확인
- [x] `dev → main` PR에서도 CI가 정상 실행되는지 확인

---

## 관련 이슈
#55 
