### PR TITLE
[feat/dockmenu-8] ✨ feat: mailto 링크 적용 및 href 테스트 추가

### DIFF
--- a/app/(shell)/_components/dock/DockMenu.test.tsx
+++ b/app/(shell)/_components/dock/DockMenu.test.tsx
@@ -17,4 +17,14 @@ describe("DockMenu", () => {
       expect(screen.getByLabelText(label)).toBeInTheDocument();
     });
   });
+
+  test("CONTACT 아이콘은 mailto 링크를 가진다", () => {
+    render(<DockMenu />);
+
+    const contact = screen.getByLabelText("CONTACT");
+    expect(contact.closest('a')).toHaveAttribute(
+      "href",
+      "mailto:musamea99@gmail.com"
+    );
+  })
 });

--- a/app/(shell)/_components/dock/DockMenu.tsx
+++ b/app/(shell)/_components/dock/DockMenu.tsx
@@ -26,9 +26,9 @@ export default function DockMenu() {
           </li>
           <li aria-hidden="true" className="h-4 w-px bg-gray-300 mx-2" />
           <li>
-            <button aria-label="CONTACT">
+            <a href="mailto:musamea99@gmail.com" aria-label="CONTACT">
               Contact
-            </button>
+            </a>
           </li>
           <li>
             <button aria-label="PHOTOBOOTH">


### PR DESCRIPTION
## 요약
- 변경 목적(왜?):  
  DockMenu에서 CONTACT이 mailto 기능을 수행하도록 구현

- 주요 변경(무엇을?):  
  CONTACT에 `mailto:` 링크 적용  
  테스트에 href 검증 테스트 케이스 추가

---

## 변경 내용
- [x] UI/컴포넌트  
  - CONTACT을 `<a href="mailto:...">` 로 변경하여 메일 전송 기능 활성화

- [x] 로직/유틸  
  - mailto 링크 적용 

- [x] 문서/설정  
  - DockMenu 테스트: CONTACT href 검증 테스트 추가

---

## 스크린샷/동영상 (선택)
<!-- UI 변경 있으면 첨부 -->

---

## 테스트
- [x] 유닛 테스트 추가/수정됨  
  - CONTACT 아이콘 mailto 링크 테스트 추가
- [x] 로컬에서 `pnpm test` 통과  
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

---

## 관련 이슈
#8
