### PR TITLE
[style/giscus-74] 💄 Style : Giscus 커스텀 스타일링 수정

### DIFF
--- a/public/giscus-dark.css
+++ b/public/giscus-dark.css
@@ -13,6 +13,29 @@ body {
     BlinkMacSystemFont, "Segoe UI", Arial, sans-serif !important;
 }
 
+*,
+:after,
+:before {
+  border: none !important;
+  box-sizing: border-box;
+}
+
+color-text-primary {
+  color: #00a9ef !important;
+}
+
+color-text-secondary {
+  color: rgba(255, 255, 255, 0.65) !important;
+}
+
+#__next .text-sm {
+  font-size: 0.775rem !important;
+}
+
+#__next .ml-1 {
+  margin-inline-start: none !important;
+}
+
 /* 버튼 스타일 전체 */
 button {
   border: none;
@@ -20,7 +43,6 @@ button {
 
 .btn {
   border: none;
-  background: #00a9ef;
 }
 
 .gsc-main,
@@ -73,10 +95,10 @@ gsc-comment,
 /* 댓글 탭 */
 .gsc-comment-box-tabs {
   background: transparent !important;
+  border-bottom-width: 0.05rem;
 }
 
 .gsc-comment-box-tabs div button {
-  color: rgba(255, 255, 255, 0.65) !important;
   font-size: 12px !important;
   font-weight: 500 !important;
   background: transparent !important;
@@ -135,7 +157,8 @@ button.form-control.color-text-secondary.color-border-primary.w-full.cursor-text
 
 /* 로그아웃+등록버튼 영역  */
 .gsc-comment-box-bottom {
-  background: #151c36 !important;
+  background: transparent !important;
+  margin: 0.8rem !important;
 }
 
 /* 로그아웃 버튼 */
@@ -156,17 +179,17 @@ button.form-control.color-text-secondary.color-border-primary.w-full.cursor-text
 }
 
 .gsc-comment-box-buttons .btn {
-    background: #d5d5d5;
-    color: white;
-    margin-left: .5rem;
-    border-radius: .5rem;
+  background: #d5d5d54a;
+  color: white;
+  margin-left: 0.5rem;
+  border-radius: 0.75rem !important;
 }
 
 .gsc-comment-box-buttons .btn-primary {
-    background: #00a9ef;
-    color: white;
-    margin-left: .5rem;
-    border-radius: .5rem;
+  background: #00a9ef;
+  color: white;
+  margin-left: 0.5rem;
+  border-radius: 0.75rem !important;
 }
 
 /* ----------------------------------------------------------------------------------- */
@@ -224,4 +247,16 @@ link-secondary {
 .gsc-comment .gsc-comment-box {
   border: none !important;
   border-radius: none !important;
+}
+
+/* 이모지창 */
+.gsc-reactions-popover {
+  background: white;
+  box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.05) !important;
+}
+
+.gsc-reactions-popover p {
+  color: #151c36;
+  text-align: center;
+  font-weight: 500;
 }

--- a/public/giscus-light.css
+++ b/public/giscus-light.css
@@ -19,6 +19,14 @@ body {
   box-sizing: border-box;
 }
 
+color-text-primary {
+  color: #00a9ef !important;
+}
+
+color-text-secondary {
+  color: rgba(36, 50, 83, 0.92) !important;
+}
+
 #__next .text-sm {
   font-size: 0.775rem !important;
 }
@@ -93,13 +101,13 @@ gsc-comment,
   border-width: none !important;
 }
 
-.gsc-comment-box-tabs {
-  background: white !important;
-  border-bottom-width: none !important;
+.color-bg-tertiary.color-border-primary.gsc-comment-box-tabs {
+  border-top-right-radius: 20px;
+  border-top-left-radius: 20px;
+  background: white;
 }
 
 .gsc-comment-box-tabs div button {
-  color: rgba(15, 23, 42, 0.65) !important;
   font-size: 12px !important;
   font-weight: 500 !important;
   background: transparent !important;
@@ -162,7 +170,8 @@ button.form-control.color-text-secondary.color-border-primary.w-full.cursor-text
 
 /* 로그아웃+등록버튼 영역  */
 .gsc-comment-box-bottom {
-  background: #f0f0f0 !important;
+  background: #f7f7f7 !important;
+  margin: 0.8rem !important;
 }
 
 /* 로그아웃 버튼 */
@@ -179,17 +188,17 @@ button.form-control.color-text-secondary.color-border-primary.w-full.cursor-text
 }
 
 .gsc-comment-box-buttons .btn {
-    background: #d5d5d5;
-    color: white;
-    margin-left: .5rem;
-    border-radius: .5rem;
+  background: #dcdcdc;
+  color: white;
+  margin-left: 0.5rem;
+  border-radius: 0.75rem !important;
 }
 
 .gsc-comment-box-buttons .btn-primary {
-    background: #00a9ef;
-    color: white;
-    margin-left: .5rem;
-    border-radius: .5rem;
+  background: #00a9ef;
+  color: white;
+  margin-left: 0.5rem;
+  border-radius: 0.75rem !important;
 }
 
 .gsc-comment-box-buttons a {
@@ -233,7 +242,7 @@ link-secondary {
 
 /* 대댓글 */
 .gsc-replies {
-  background: #F7F7F7 !important;
+  background: #f7f7f7 !important;
   border: none !important;
 }
 
@@ -250,4 +259,16 @@ link-secondary {
 .gsc-comment .gsc-comment-box {
   border: none !important;
   border-radius: none !important;
+}
+
+/* 이모지창 */
+.gsc-reactions-popover {
+  background: white;
+  box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.05) !important;
+}
+
+.gsc-reactions-popover p {
+  color: #151c36;
+  text-align: center;
+  font-weight: 500;
 }


### PR DESCRIPTION
## 요약
- 변경 목적(왜?): Giscus 커스텀 스타일링 수정
- 주요 변경(무엇을?): 
- [ ] 이모지 배경 없음 (라이트/다크) 
- [ ] 아직도 입력창 밑에 색 변경 (라이트/다크) 
- [ ] 탭 배경 제거 (라이트)
- [ ] 탭 selected - color 로 변경 (라이트/다크) 
- [ ] 제거되지 않은 선 제거 (다크) 
- [ ] 버튼 색상 더 연하게 변경 (다크)

## 변경 내용
- [ ] UI/컴포넌트
- [ ] 로직/유틸
- [ ] 문서/설정

## 스크린샷/동영상 (선택)
<!-- UI 변경 있으면 첨부 -->

## 테스트
- [ ] 유닛 테스트 추가/수정됨
- [ ] 로컬에서 `pnpm test` 통과
- [ ] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈
close #74 