### PR TITLE
[infra/cloudinary-108] ✨ feat:  Cloudinary 원격 이미지 도메인 허용 설정 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,15 @@ const nextConfig: NextConfig = {
     },
   },
 
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "res.cloudinary.com",
+      },
+    ],
+  },
+
   webpack: (config) => {
     // @ts-expect-error: Next
     const fileLoaderRule = config.module.rules.find((rule) =>


### PR DESCRIPTION
## 요약
- 변경 목적(왜?):
  - Cloudinary CDN 경로의 원격 이미지를 `next/image`로 최적화하여 사용할 수 있도록 허용하기 위함
- 주요 변경(무엇을?):
  - `next.config.ts`에 `images.remotePatterns` 항목 추가

## 변경 내용
- [ ] UI/컴포넌트
- [ ] 로직/유틸
- [x] 문서/설정 (`next.config.ts`)

### 상세
- `res.cloudinary.com` 호스트의 HTTPS 이미지 요청을 허용하도록 설정 추가
- 이후 MDX frontmatter 혹은 본문에서 Cloudinary CDN URL 사용 시 이미지 로딩 최적화 + 리사이즈 지원

## 스크린샷/동영상 (선택)
<!-- 설정 변경이라 해당 없음 -->

## 테스트
- [ ] 유닛 테스트 추가/수정됨
- [x] 로컬에서 `pnpm build`/`pnpm dev` 정상 동작 확인
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈
close #108 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기타**
  * Cloudinary의 원격 이미지 지원을 위한 이미지 최적화 설정 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->